### PR TITLE
fix localizing arguments section on method page

### DIFF
--- a/tasks/lib/slack_api/methods_spider.rb
+++ b/tasks/lib/slack_api/methods_spider.rb
@@ -43,7 +43,7 @@ module SlackApi
     private
 
     def parse_args(api_page, default_data = {})
-      args_wrapper = api_page.search("h2:contains('Arguments') + p + table")
+      args_wrapper = api_page.search("h2:contains('Arguments') + table")
       rows = args_wrapper.search('tr')
       args = {}
       fields = {}


### PR DESCRIPTION
Refs https://github.com/slack-ruby/slack-ruby-client/issues/193