### PR TITLE
Update links to point to slack-ruby org instead of dblock fork

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 Contributing
 ============
 
-This project is work of [many contributors](https://github.com/dblock/slack-api-ref/graphs/contributors). You're encouraged to submit [pull requests](https://github.com/dblock/slack-api-ref/pulls) and [propose topics](https://github.com/dblock/slack-api-ref/issues).
+This project is work of [many contributors](https://github.com/slack-ruby/slack-api-ref/graphs/contributors). You're encouraged to submit [pull requests](https://github.com/dblock/slack-api-ref/pulls) and [propose topics](https://github.com/dblock/slack-api-ref/issues).
 
 #### Fork the Project
 
-Fork the [project on Github](https://github.com/dblock/slack-api-ref) and check out your copy.
+Fork the [project on Github](https://github.com/slack-ruby/slack-api-ref) and check out your copy.
 
 ```
 git clone https://github.com/contributor/slack-api-ref.git
 cd slack-api-ref
-git remote add upstream https://github.com/dblock/slack-api-ref.git
+git remote add upstream https://github.com/slack-ruby/slack-api-ref.git
 ```
 
 #### Create a Topic Branch

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you need to trigger an update right now, run `rake api:update`. To check if a
 
 The reference is used by the following client projects to generate API client code.
 
-* [slack-ruby-client](https://github.com/dblock/slack-ruby-client): Slack Ruby Client
+* [slack-ruby-client](https://github.com/slack-ruby/slack-ruby-client): Slack Ruby Client
 
 ### Slack
 


### PR DESCRIPTION
Similar to https://github.com/slack-ruby/slack-ruby-client/pull/300, I noticed while following the contributing instructions that some links hadn't been updated to the `slack-ruby` org.