### PR TITLE
Manually triggerable API update

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,6 +1,7 @@
 name: update
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "15 22 * * *"
 


### PR DESCRIPTION
Sets up the `update` GitHub Actions workflow to be manually triggerable as described in [Manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).

**Run workflow** button should appear when the configuration is merged into the main branch
![](https://docs.github.com/assets/cb-57703/images/actions-workflow-dispatch.png)

Closes #56 