### PR TITLE
Mark text/markdown_text arg_group as not required in chat methods

### DIFF
--- a/methods/chat/chat.postEphemeral.json
+++ b/methods/chat/chat.postEphemeral.json
@@ -151,6 +151,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]

--- a/methods/chat/chat.postMessage.json
+++ b/methods/chat/chat.postMessage.json
@@ -207,6 +207,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]

--- a/methods/chat/chat.scheduleMessage.json
+++ b/methods/chat/chat.scheduleMessage.json
@@ -168,6 +168,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]

--- a/methods/chat/chat.update.json
+++ b/methods/chat/chat.update.json
@@ -183,6 +183,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]


### PR DESCRIPTION
### Problem

`chat.postEphemeral`, `chat.postMessage`, `chat.scheduleMessage` and `chat.update` each declare a `mutually_exclusive: true` arg_group for `[text, markdown_text]`, meaning at most one of them may be given, not that exactly one is required (they may both be omitted as long as another required arg, e.g. `attachments` or `blocks`, is present).

However, this arg_group has no `required` key. Downstream consumers (e.g. [slack-ruby-client](https://github.com/slack-ruby/slack-ruby-client)) default missing `required` to `true` for `mutually_exclusive` groups, which generates an incorrect "exactly one of :text, :markdown_text is required" (XOR) validation instead of an "at most one" (mutually exclusive) validation. This caused a regression each time slack-ruby-client regenerated its API bindings from this repo (see [slack-ruby/slack-ruby-client#588](https://github.com/slack-ruby/slack-ruby-client/pull/588)), because the fix there could only live as an ephemeral, uncommitted local patch to this submodule's checkout rather than a durable upstream change.

### Fix

Add `"required": false` to the `[text, markdown_text]` arg_group in all 4 affected chat method JSON files, so consumers can correctly distinguish "at most one" from "exactly one" mutually-exclusive argument groups.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>