### PR TITLE
Fix text/markdown_text mutual exclusion patch source (persist required: false)

### DIFF
--- a/methods/_patches/chat/chat.postEphemeral.json
+++ b/methods/_patches/chat/chat.postEphemeral.json
@@ -16,6 +16,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]

--- a/methods/_patches/chat/chat.postMessage.json
+++ b/methods/_patches/chat/chat.postMessage.json
@@ -16,6 +16,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]

--- a/methods/_patches/chat/chat.scheduleMessage.json
+++ b/methods/_patches/chat/chat.scheduleMessage.json
@@ -16,6 +16,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]

--- a/methods/_patches/chat/chat.update.json
+++ b/methods/_patches/chat/chat.update.json
@@ -16,6 +16,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]

--- a/methods/chat/chat.postEphemeral.json
+++ b/methods/chat/chat.postEphemeral.json
@@ -158,6 +158,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]

--- a/methods/chat/chat.postMessage.json
+++ b/methods/chat/chat.postMessage.json
@@ -208,6 +208,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]

--- a/methods/chat/chat.scheduleMessage.json
+++ b/methods/chat/chat.scheduleMessage.json
@@ -168,6 +168,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]

--- a/methods/chat/chat.update.json
+++ b/methods/chat/chat.update.json
@@ -183,6 +183,7 @@
         "markdown_text"
       ],
       "desc": "Use either text or markdown_text, but not both.",
+      "required": false,
       "mutually_exclusive": true
     }
   ]


### PR DESCRIPTION
## Problem

#84 fixed the `[text, markdown_text]` `mutually_exclusive` arg_group in `chat.postEphemeral`, `chat.postMessage`, `chat.scheduleMessage` and `chat.update` by adding `"required": false` directly to the merged output files in `methods/chat/*.json`. Without it, downstream consumers (e.g. slack-ruby-client) treat a missing `required` flag on a `mutually_exclusive` group as "exactly one is required" (XOR), when in fact `text`/`markdown_text` can both be omitted as long as another required arg (e.g. `attachments` or `blocks`) is present.

That fix only touched the generated output (`methods/chat/*.json`), not the `methods/_patches/chat/*.json` source files that `rake api:methods:update` merges on top of freshly scraped docs (see `process_method` in `tasks/lib/slack_api/methods_generator.rb`, which does `result.merge!(patch)`). The very next doc scrape (634d6648, 2026/08/10) regenerated the merged files from docs + the still-unfixed patches, silently dropping `required: false` again. This surfaced downstream in slack-ruby/slack-ruby-client#590, where CI failed because `chat_postMessage`/`chat_postEphemeral`/etc. once again raised `ArgumentError, 'Exactly one of :text, :markdown_text is required'` when only `text` (or only `markdown_text`) was passed.

## Fix

Add `"required": false` to the `[text, markdown_text]` arg_group in the four `methods/_patches/chat/*.json` source files, so the fix persists across future doc re-scrapes, and regenerate the merged `methods/chat/*.json` files (via `rake api:methods:update`) to match.

Verified with `rake api:methods:update` (regenerates only the intended 4 merged files, no other diffs) and `rake api:methods:validate` (passes).
