### PR TITLE
Fix YAML indentation bug in AI prompt template substitution

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Prepare diff for AI summary
         if: steps.changes.outputs.changed == 'true'
         run: |
-          git diff --stat > /tmp/diff_stat.txt
-          git diff | head -c 20000 > /tmp/diff.txt
+          git diff --stat | sed 's/^/      /' > /tmp/diff_stat.txt
+          git diff | head -c 20000 | sed 's/^/      /' > /tmp/diff.txt
       - name: Generate commit message with AI
         if: steps.changes.outputs.changed == 'true'
         id: ai

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Some notable infrastructure contributions below. See [commits](commits/master) for Slack API updates.
 
 * Your contribution here.
+* [#88](https://github.com/slack-ruby/slack-api-ref/pull/88): Fix a YAML indentation bug in AI commit message generation - [@dblock](https://github.com/dblock).
 * [#87](https://github.com/slack-ruby/slack-api-ref/pull/87): Generate AI commit summaries for automated API updates - [@dblock](https://github.com/dblock).
 * [#64](https://github.com/slack-ruby/slack-api-ref/pull/64): Add `arg_groups` for groups of arguments whose requirement is interdependent - [@jmanian](https://github.com/jmanian).
 * [#64](https://github.com/slack-ruby/slack-api-ref/pull/64): Add `"format": "json"` attribute for arguments that need to be JSON strings - [@jmanian](https://github.com/jmanian).


### PR DESCRIPTION
## Problem

The `update.yml` workflow's AI commit-message generation step ([#87](https://github.com/slack-ruby/slack-api-ref/pull/87)) is fragile: `actions/ai-inference@v1` substitutes `{{diff_stat}}`/`{{diff}}` placeholders as **raw text** into the prompt YAML file *before* parsing it as YAML. Since the diff/diff-stat files were written starting at column 0, injecting multi-line content can break the indentation of the enclosing `content: |-` block scalar in `commit-message.prompt.yml`, causing:

```
##[error]Failed to parse prompt file: bad indentation of a mapping entry
```

This exact failure mode was confirmed in the sibling workflow in [slack-ruby/slack-ruby-client#592](https://github.com/slack-ruby/slack-ruby-client/pull/592) (https://github.com/slack-ruby/slack-ruby-client/actions/runs/31552877245/job/93979138338).

## Fix

Pipe the diff/diff-stat output through `sed 's/^/      /'` (6 spaces, matching the prompt file's block scalar indentation) before writing them to the files consumed via `file_input`, so the substituted content stays inside the block and parses correctly.
