### PR TITLE
Migrate AI commit message generation to Copilot CLI

### DIFF
--- a/.github/prompts/commit-message.prompt.yml
+++ b/.github/prompts/commit-message.prompt.yml
@@ -3,13 +3,15 @@ messages:
     content: |-
       You write concise git commit messages describing automated updates to a Slack Web
       API reference JSON repository (methods, groups and events scraped from Slack's docs).
-      Given a diffstat and a diff, respond with:
+      Given a diffstat and a diff, respond with ONLY a single JSON object (no markdown code
+      fences, no other text) with exactly these two keys:
+      {"title": "...", "summary": "..."}
       - title: a single line, imperative mood, at most 72 characters, no trailing period,
         describing the most significant change (e.g. "Add chat.appendStream and
         chat.stopStream methods").
       - summary: 1-5 short bullet points (each starting with "- "), each describing one
         notable change: new/removed/renamed methods or events, added/removed arguments,
-        changed error codes, etc.
+        changed error codes, etc. Use "" if nothing notable.
       If the diff is routine or has no notable API surface changes, keep the title generic
       (e.g. "Minor documentation updates") and the summary brief or empty.
   - role: user
@@ -19,25 +21,3 @@ messages:
 
       Diff (may be truncated):
       {{diff}}
-model: openai/gpt-4o-mini
-responseFormat: json_schema
-jsonSchema: |-
-  {
-    "name": "commit_message",
-    "strict": true,
-    "schema": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Single-line, imperative-mood commit title, max 72 characters, no trailing period"
-        },
-        "summary": {
-          "type": "string",
-          "description": "1-5 short bullet points, each starting with '- ', or empty string if nothing notable"
-        }
-      },
-      "additionalProperties": false,
-      "required": ["title", "summary"]
-    }
-  }

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  models: read
 
 jobs:
   update:
@@ -39,25 +38,35 @@ jobs:
       - name: Prepare diff for AI summary
         if: steps.changes.outputs.changed == 'true'
         run: |
-          git diff --stat > /tmp/diff_stat.txt
-          git diff | head -c 20000 > /tmp/diff.txt
+          git diff --stat | sed 's/^/      /' > /tmp/diff_stat.txt
+          git diff | head -c 20000 | sed 's/^/      /' > /tmp/diff.txt
+      - name: Set up Node
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-node@v6
+      - name: Install Copilot CLI
+        if: steps.changes.outputs.changed == 'true'
+        run: npm install -g @github/copilot
       - name: Generate commit message with AI
         if: steps.changes.outputs.changed == 'true'
         id: ai
-        uses: actions/ai-inference@v1
+        uses: actions/ai-inference@v3
         with:
           prompt-file: ./.github/prompts/commit-message.prompt.yml
+          model: ''
           file_input: |
             diff_stat: /tmp/diff_stat.txt
             diff: /tmp/diff.txt
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}
       - name: Build commit message
         id: message
         run: |
           title=""
           summary=""
           if [ "${{ steps.changes.outputs.changed }}" = "true" ]; then
-            title="$(jq -r '.title // empty' "${{ steps.ai.outputs.response-file }}" 2>/dev/null)"
-            summary="$(jq -r '.summary // empty' "${{ steps.ai.outputs.response-file }}" 2>/dev/null)"
+            response="$(grep -v '^```' "${{ steps.ai.outputs.response-file }}" 2>/dev/null)"
+            title="$(echo "$response" | jq -r '.title // empty' 2>/dev/null)"
+            summary="$(echo "$response" | jq -r '.summary // empty' 2>/dev/null)"
           fi
           if [ -z "$title" ]; then
             title="Updated from Slack docs, ${CURRENT_DATE}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Some notable infrastructure contributions below. See [commits](commits/master) for Slack API updates.
 
 * Your contribution here.
+* [#89](https://github.com/slack-ruby/slack-api-ref/pull/89): Migrate AI commit message generation to Copilot CLI after GitHub Models retirement - [@dblock](https://github.com/dblock).
 * [#87](https://github.com/slack-ruby/slack-api-ref/pull/87): Generate AI commit summaries for automated API updates - [@dblock](https://github.com/dblock).
 * [#64](https://github.com/slack-ruby/slack-api-ref/pull/64): Add `arg_groups` for groups of arguments whose requirement is interdependent - [@jmanian](https://github.com/jmanian).
 * [#64](https://github.com/slack-ruby/slack-api-ref/pull/64): Add `"format": "json"` attribute for arguments that need to be JSON strings - [@jmanian](https://github.com/jmanian).


### PR DESCRIPTION
## Problem

GitHub Models (`models.github.ai`, the backend `actions/ai-inference@v1` used for AI commit summaries in [#87](https://github.com/slack-ruby/slack-api-ref/pull/87)) was **fully retired on July 30, 2026**:

```
Error: 410 GitHub Models is temporarily unavailable as part of a scheduled retirement brownout.
```

This is permanent, not a temporary outage — every scheduled `update.yml` run will fail from now on.

## Fix

`actions/ai-inference` was rewritten (v3, released July 29, 2026) to exclusively shell out to the **GitHub Copilot CLI** instead of calling GitHub Models. This PR updates the workflow accordingly:

- Installs and authenticates the Copilot CLI (`npm install -g @github/copilot`) before invoking `actions/ai-inference@v1`, using `COPILOT_GITHUB_TOKEN` sourced from a new `COPILOT_PAT` repo secret.
- Drops the now-unnecessary `models: read` permission.
- The v3 action also dropped structured JSON schema output (`responseFormat`/`jsonSchema`), so the prompt now asks for a bare JSON object with no markdown fences, and the "Build commit message" step strips any ` ``` ` fences defensively before parsing with `jq`.

## ⚠️ Action required

This requires adding a **`COPILOT_PAT`** secret (a PAT for an account with Copilot CLI access) to this repository's Actions secrets for the workflow to actually run. Copilot CLI usage is free for individual accounts (with monthly limits) and open source maintainers can request higher/unlimited access — see https://github.com/features/copilot/plans.
